### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ YAML loader for [webpack](http://webpack.github.io/). Converts YAML to JSON. You
 
 ## Installation
 
-`npm install yml-loader`
+`npm install yaml-loader`
 
 ## Usage
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
 ``` javascript
-var json = require("yml!./file.yml");
-// => returns json from file.yml. Pass it to json-loader to obtain the Native Object
+var json = require("json!yaml!./file.yml");
+// => returns file.yml as javascript object
 ```
 
 ## License


### PR DESCRIPTION
Fixed a spelling mistake in the Installation-chapter and changed the example to the most common use-case.

I know, you wrote it twice to use it together with the json-loader, but I still forgot to add it :grin:. Since this is the most common use-case I added the json-loader to the example.
