### PR TITLE
Add option to suppress js-yaml warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ var json = require("json!yaml!./file.yml");
 // => returns file.yml as javascript object
 ```
 
+### Options
+
+**force**
+By default the YAML parser throws errors when it encounters a warning. Sometimes you want to suppress this, e.g.:
+
+```yaml
+# questionable.yml
+# YAML that works, but js-yaml warns about
+foo: {
+    bar: true
+}
+```
+
+```js
+var json = require("json!yaml?force!./questionable.yml");
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,18 @@
 var yaml = require('js-yaml');
+var loaderUtils = require('loader-utils');
+var assign = require('object-assign');
 
 module.exports = function (source) {
   this.cacheable && this.cacheable();
-  var res = yaml.safeLoad(source);
+
+  var opts = assign({
+    force: false
+  }, loaderUtils.parseQuery(this.query));
+
+  var jsYamlOpts = {
+    onWarning: opts.force ? function() {} : null
+  };
+
+  var res = yaml.safeLoad(source, jsYamlOpts);
   return JSON.stringify(res, undefined, '\t');
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "homepage": "https://github.com/okonet/yaml-loader",
   "dependencies": {
-    "js-yaml": "^3.0.2"
+    "js-yaml": "^3.0.2",
+    "loader-utils": "^0.2.10",
+    "object-assign": "^3.0.0"
   }
 }


### PR DESCRIPTION
Couldn't load technically valid yaml like

```yaml
foo: {
    bar: true
}
```

because `js-yaml` gives a whitespace warning here. I think this is an issue with `js-yaml`, I've [reported it](https://github.com/nodeca/js-yaml/issues/194).

This file parses successfully if we suppress warnings in `js-yaml`, so I've exposed that option in the loader.