### PR TITLE
Webpack loader options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ var json = require("json!yaml!./file.yml");
 // => returns file.yml as javascript object
 ```
 
+## Configure
+
+``` javascript
+
+// webpack.config.js
+
+var yamlinc = require("yaml-include");
+
+module.exports = {
+  // ... snip
+  yaml: { // All keys in yaml will be passed to js-yaml as options
+    schema: yamlinc.YAML_INCLUDE_SCHEMA
+  }
+};
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var yaml = require('js-yaml');
 
 module.exports = function (source) {
   this.cacheable && this.cacheable();
-  var res = yaml.safeLoad(source);
+  var options = this.options.yaml;
+  options.filename = this.resourcePath;
+  var res = yaml.load(source, options);
   return JSON.stringify(res, undefined, '\t');
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/okonet/yaml-loader",
   "dependencies": {
-    "js-yaml": "^3.5.2"
+    "js-yaml": "^3.5.2",
+    "loader-utils": "^0.2.15"
   }
 }


### PR DESCRIPTION
Allow passing params to js-yaml via loader config. I needed this to use the custom schema from https://github.com/claylo/yaml-include.