### PR TITLE
Drop support for Webpack v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ the loader supports the following additional options:
 
 ### `asJSON`
 
-If enabled, the loader output is stringified JSON rather than stringified JavaScript. For Webpack v4, you'll need to set the rule to have `type: "json"`. Also useful for chaining with other loaders that expect JSON input.
+If enabled, the loader output is stringified JSON rather than stringified JavaScript.
+Also useful for chaining with other loaders that expect JSON input.
 
 ### `asStream`
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const { getOptions } = require('loader-utils')
 const { stringify } = require('javascript-stringify')
 const YAML = require('yaml')
 
@@ -7,7 +6,7 @@ const makeIdIterator = (prefix = 'v', i = 1) => ({ next: () => prefix + i++ })
 module.exports = function yamlLoader(src) {
   const { asJSON, asStream, ...options } = Object.assign(
     { prettyErrors: true },
-    this.getOptions?.() ?? getOptions(this)
+    this.getOptions()
   )
   const namespace =
     (this.resourceQuery &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "javascript-stringify": "^2.0.1",
-        "loader-utils": "^2.0.0",
         "yaml": "^2.0.0"
       },
       "devDependencies": {
@@ -1509,15 +1508,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1864,15 +1854,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
@@ -3119,6 +3100,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3166,20 +3148,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "javascript-stringify": "^2.0.1",
-    "loader-utils": "^2.0.0",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/test/direct.test.js
+++ b/test/direct.test.js
@@ -2,14 +2,14 @@ const loader = require('..')
 
 describe('aliased objects', () => {
   test('single document', () => {
-    const ctx = {}
+    const ctx = { getOptions: () => ({}) }
     const src = 'foo: &foo [&val foo]\nbar: *foo'
     const res = loader.call(ctx, src)
     expect(res).toBe("var v1 = ['foo'];\nexport default {foo:v1,bar:v1};")
   })
 
   test('document stream', () => {
-    const ctx = { query: { asStream: true } }
+    const ctx = { getOptions: () => ({ asStream: true }) }
     const src = 'foo: &foo [foo]\nbar: *foo\n---\nfoo: &foo [foo]\nbar: *foo'
     const res = loader.call(ctx, src)
     expect(res).toBe(
@@ -20,14 +20,14 @@ describe('aliased objects', () => {
 
 describe('options.asJSON', () => {
   test('return stringify version of the yaml file', () => {
-    const ctx = { query: { asJSON: true } }
+    const ctx = { getOptions: () => ({ asJSON: true }) }
     const src = '---\nhello: world'
     const res = loader.call(ctx, src)
     expect(res).toBe('{"hello":"world"}')
   })
 
   test('throw error if there is a parse error', () => {
-    const ctx = { query: { asJSON: true } }
+    const ctx = { getOptions: () => ({ asJSON: true }) }
     const src = '---\nhello: world\nhello: 2'
     expect(() => loader.call(ctx, src)).toThrow(/Map keys must be unique/)
   })
@@ -35,13 +35,13 @@ describe('options.asJSON', () => {
 
 describe('options.namespace', () => {
   test('return a part of the yaml', () => {
-    const ctx = { query: '?namespace=hello' }
+    const ctx = { getOptions: () => ({ namespace: 'hello' }) }
     const res = loader.call(ctx, '---\nhello:\n  world: plop')
     expect(res).toBe("export default {world:'plop'};")
   })
 
   test('return a sub-part of the yaml', () => {
-    const ctx = { query: '?namespace=hello.world' }
+    const ctx = { getOptions: () => ({ namespace: 'hello.world' }) }
     const res = loader.call(ctx, '---\nhello:\n  world: plop')
     expect(res).toBe("export default 'plop';")
   })
@@ -49,14 +49,14 @@ describe('options.namespace', () => {
 
 describe('options.asStream', () => {
   test('with asStream, parse multiple documents', () => {
-    const ctx = { query: { asStream: true } }
+    const ctx = { getOptions: () => ({ asStream: true }) }
     const src = 'hello: world\n---\nsecond: document\n'
     const res = loader.call(ctx, src)
     expect(res).toBe("export default [{hello:'world'},{second:'document'}];")
   })
 
   test('without asStream, fail to parse multiple documents', () => {
-    const ctx = { query: { asStream: false } }
+    const ctx = { getOptions: () => ({ asStream: false }) }
     const src = 'hello: world\n---\nsecond: document\n'
     expect(() => loader.call(ctx, src)).toThrow(/yaml-loader asStream option/)
   })
@@ -64,13 +64,13 @@ describe('options.asStream', () => {
 
 describe('yaml options', () => {
   test('options.intAsBigInt', () => {
-    const ctx = { query: { intAsBigInt: true } }
+    const ctx = { getOptions: () => ({ intAsBigInt: true }) }
     const res = loader.call(ctx, 'answer: 42')
     expect(res).toBe("export default {answer:BigInt('42')};")
   })
 
   test('options.mapAsMap', () => {
-    const ctx = { query: { mapAsMap: true } }
+    const ctx = { getOptions: () => ({ mapAsMap: true }) }
     const res = loader.call(ctx, '---\nhello:\n  world: plop')
     expect(res).toBe(
       "export default new Map([['hello',new Map([['world','plop']])]]);"


### PR DESCRIPTION
Webpack v5 has been available for a little over 5 years now; it's time to drop support for its v4 version.